### PR TITLE
pass `-f` to docker-compose rm to remove container silently.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,14 @@ build:
 reload: build stop-hubot run-hubot
 
 run-redis:
-	- docker-compose rm redis
+	- docker-compose rm -f redis
 	docker-compose up -d redis
 
 stop-redis:
 	- docker-compose stop redis
 
 run-hubot:
-	- docker-compose rm hubot
+	- docker-compose rm -f hubot
 	docker-compose up -d hubot
 
 stop-hubot:


### PR DESCRIPTION
Currently `make run-hubot` ask me to remove current container as follows.

```
Going to remove hubot-groovenauts
Are you sure? [yN] y
```

In cron job `make run-hubot` is executed to restart hubot if it's exited and cron jobs perhaps failed by this prompt I think.
- [x] @minimum2scp 
